### PR TITLE
Deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,21 @@ Here you can find simple example projects,
 showing how to integrate [**JavaThemis**](https://github.com/cossacklabs/themis#readme)
 into desktop applications in Java and Android applications in Kotlin.
 
+---
+
+⚠️ **Repository is archived** 📚
+
+We moved the example projects to the main repository to keep them up-to-date more easily:
+
+  - [`docs/examples/android`](https://github.com/cossacklabs/themis/tree/master/docs/examples/android) – Android application in Kotlin
+  - [`docs/examples/java`](https://github.com/cossacklabs/themis/tree/master/docs/examples/java) – desktop application in Java
+
+Examples provided here are not maintained and use JavaThemis 0.13.
+For up-to-date example projects using the latest version of Themis,
+please refer to the main repository.
+
+---
+
 Learn more about [using Themis in Java applications](https://docs.cossacklabs.com/themis/languages/java/)
 as well as [writing Android applications in Kotlin](https://docs.cossacklabs.com/themis/languages/kotlin/).
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Themis examples for Java and Android
 
-Desktop Java and Android Java simple example projects.
+Here you can find simple example projects,
+showing how to integrate [**JavaThemis**](https://github.com/cossacklabs/themis#readme)
+into desktop applications in Java and Android applications in Kotlin.
 
-These are demo projects that enhance documentation for Java and Android:
-
-https://docs.cossacklabs.com/pages/java-and-android-howto/
+Learn more about [using Themis in Java applications](https://docs.cossacklabs.com/themis/languages/java/)
+as well as [writing Android applications in Kotlin](https://docs.cossacklabs.com/themis/languages/kotlin/).
 
 ## How to run?
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
+# Themis examples for Java and Android
+
 Desktop Java and Android Java simple example projects.
 
 These are demo projects that enhance documentation for Java and Android:
 
 https://docs.cossacklabs.com/pages/java-and-android-howto/
 
-# How to run?
+## How to run?
 
 ### Java example
 
@@ -29,7 +31,7 @@ option `java.library.path=/path/to/dir_with_libthemis_jni.so`.
 2. Included library Themis for Android via bintray maven repository (see below).
 3. Run `MainActivitySecureCell` as secure data storage or `MainActivitySecureMessage` to see secure messaging example.
 
-# What are these examples?
+## What are these examples?
 
 Client code (both Android and Java) contains simple example for symmetric and asymmetric encryption.
 
@@ -77,7 +79,7 @@ secureMessageLocal
 ```
 
 
-# Themis Interactive simulator
+## Themis Interactive simulator
 
 Both examples contain ready-to-use solutions to test asymmetric encryption with Themis Interactive Server.
 No need to run your own server to check if you have implemented encryption correctly.
@@ -87,7 +89,7 @@ For Java check `SMessageClient` and `SSessionClient`. For Android check `MainAct
 Comprehensive documentation can be found below: https://docs.cossacklabs.com/simulator/interactive/
 
 
-# How to install Themis
+## How to install Themis
 
 ### For Desktop Java
 


### PR DESCRIPTION
Now that both Android and Java examples have been moved to the main repository, we don't really have to maintain this one anymore. Let's tidy up the remains, slap a deprecation notice, and provide links where the users should be able to find newer code.

@vixentael, once this PR is merged, I believe the repository can also be [marked as archived](https://github.com/cossacklabs/themis-java-examples/settings#danger-zone) in the admin settings.